### PR TITLE
use cwd directive to pass the tags and labels file generated by meta step to bake

### DIFF
--- a/.github/workflows/transformer-images.yaml
+++ b/.github/workflows/transformer-images.yaml
@@ -148,7 +148,9 @@ jobs:
             *.cache-to=type=gha,scope=transformer-images,mode=max
 
   release:
-    permissions: write # for release-action
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for release-action
     steps:
       -
         name: GitHub Release


### PR DESCRIPTION
Currently we only generate and push the `latest` tag to Docker Hub 🫣