### PR TITLE
add dedicated targets for building local version of the images

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go build -o /go/bin/transform
 
 build the transformer base image for local architecture
 ```shell
-docker bake -f docker-bake.hcl transformer
+docker bake -f docker-bake.hcl transformer_local
 ```
 
 build the transformer base image for all architectures
@@ -35,7 +35,7 @@ docker bake -f docker-bake.hcl transformer_all
 
 build the kubernetes transformer image for local architecture
 ```shell
-docker bake -f docker-bake.hcl kubernetes
+docker bake -f docker-bake.hcl kubernetes_local
 ```
 
 build the kubernetes transformer image for all architectures
@@ -45,7 +45,7 @@ docker bake -f docker-bake.hcl kubernetes_all
 
 build the helm transformer image for local architecture
 ```shell
-docker bake -f docker-bake.hcl helm
+docker bake -f docker-bake.hcl helm_local
 ```
 
 build the helm transformer image for all architectures

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -20,29 +20,41 @@ target "_all-platforms" {
 target "transformer" {
   inherits = ["meta-helper"]
   target = "transformer"
-  tags = ["docker/compose-bridge-transformer"]
 }
 
 target "transformer_all" {
   inherits = ["transformer", "_all-platforms"]
 }
 
+target "transformer_local" {
+    inherits = ["transformer"]
+    tags = ["docker/compose-bridge-transformer"]
+}
+
 target "kubernetes" {
   inherits = ["meta-helper"]
   target = "kubernetes"
-  tags = ["docker/compose-bridge-kubernetes"]
 }
 
 target "kubernetes_all" {
   inherits = ["kubernetes", "_all-platforms"]
 }
 
+target "kubernetes_local" {
+    inherits = ["kubernetes"]
+    tags = ["docker/compose-bridge-kubernetes"]
+}
+
 target "helm" {
   inherits = ["meta-helper"]
   target = "helm"
-  tags = ["docker/compose-bridge-helm"]
 }
 
 target "helm_all" {
   inherits = ["helm", "_all-platforms"]
+}
+
+target "helm_local" {
+    inherits = ["helm"]
+    tags = ["docker/compose-bridge-helm"]
 }


### PR DESCRIPTION
Current the CI metadata action can't override the default `tags` definitions setup in the hcl definition which means we only get the `latest` tag to be pushed on the Hub
Adding dedicated target for local build allow us to move the local tag definition to those specific target only