### PR TITLE
fix incorrect compose->k8s mapping: command->args / entrypoint->command

### DIFF
--- a/helm-templates/templates/deployment.tmpl
+++ b/helm-templates/templates/deployment.tmpl
@@ -40,8 +40,10 @@ spec:
         - name: {{ if $service.container_name }}{{ $service.container_name | safe}}{{ else }}{{ $name | safe}}{{ end }}
           image: {{ helmValue ".Values.%s.image" $name }}
           imagePullPolicy: {{ helmValue ".Values.%s.imagePullPolicy" $name }}
+{{ if $service.entrypoint }}
+          command: {{ $service.entrypoint }}{{ end }}
 {{ if $service.command }}
-          command: {{ $service.command }}{{ end }}
+          args: {{ $service.command }}{{ end }}
 {{ if $service.working_dir }}
           workingDir: {{ $service.working_dir }}{{ end }}
 {{ if $service.environment }}

--- a/templates/base/deployment.tmpl
+++ b/templates/base/deployment.tmpl
@@ -39,8 +39,10 @@ spec:
         - name: {{ if $service.container_name }}{{ $service.container_name | safe }}{{ else }}{{ $name | safe }}{{ end }}
           image: {{ if $service.image }}{{ $service.image }}{{ else }}{{ $project }}-{{ $name }}{{ end }}
           imagePullPolicy: {{ if $service.pull_policy }}{{ $service.pull_policy | title }}{{ else }}IfNotPresent{{ end }}
+{{ if $service.entrypoint }}
+          command: {{ $service.entrypoint }}{{ end }}
 {{ if $service.command }}
-          command: {{ $service.command }}{{ end }}
+          args: {{ $service.command }}{{ end }}
 {{ if $service.working_dir }}
           workingDir: {{ $service.working_dir }}{{ end }}
 {{ if $service.environment }}


### PR DESCRIPTION
When reviewing the docs from another conversion tool Kompose (https://kompose.io/conversion/), it seems like the mapping of `command` in compose should be mapped to `args` in helm/k8s, and `entrypoint` in compose should be mapped to `args` in helm/k8s.