### PR TITLE
Support model runner

### DIFF
--- a/helm-templates/templates/deployment.tmpl
+++ b/helm-templates/templates/deployment.tmpl
@@ -44,11 +44,16 @@ spec:
           command: {{ $service.command }}{{ end }}
 {{ if $service.working_dir }}
           workingDir: {{ $service.working_dir }}{{ end }}
-{{ if $service.environment }}
+{{ if or $service.environment $service.models }}
           env:
 {{ range $key, $value := $service.environment }}
             - name: {{ $key }}
               value: {{ printf "%q" $value }}{{ end }}
+{{ range $key, $value := $service.models }}
+            - name: {{ if $value.endpoint_var }}{{ $value.endpoint_var }}{{ else }}{{ $key | uppercase }}_URL{{ end }}
+              value: {{ helmValue ".Values.modelRunner.endpoint" }}
+            - name: {{ if $value.model_var }}{{ $value.model_var }}{{ else }}{{ $key | uppercase }}_MODEL{{ end }}
+              value: "{{ or (index $.models $key).model $key }}"{{ end }}
 {{ end }}
 
 {{ if or $service.user $service.group_add $service.sysctls $service.read_only $service.privileged $service.cap_add $service.cap_drop }}

--- a/helm-templates/values.tmpl
+++ b/helm-templates/values.tmpl
@@ -26,6 +26,13 @@ storage:
   defaultSize: "100Mi"
   defaultAccessMode: "ReadWriteOnce"
 
+{{ if .models }}
+# Model Runner settings
+modelRunner:
+  # Endpoint for Docker Model Runner (Docker Desktop host instance)
+  endpoint: "http://host.docker.internal:12434/engines/v1/"
+{{ end }}
+
 # Services variables
 {{ range $name, $service := .services }}
 {{ $name }}:

--- a/templates/base/deployment.tmpl
+++ b/templates/base/deployment.tmpl
@@ -43,11 +43,16 @@ spec:
           command: {{ $service.command }}{{ end }}
 {{ if $service.working_dir }}
           workingDir: {{ $service.working_dir }}{{ end }}
-{{ if $service.environment }}
+{{ if or $service.environment $service.models }}
           env:
 {{ range $key, $value := $service.environment }}
             - name: {{ $key }}
               value: {{ printf "%q" $value }}{{ end }}
+{{ range $key, $value := $service.models }}
+            - name: {{ if $value.endpoint_var }}{{ $value.endpoint_var }}{{ else }}{{ $key | uppercase }}_URL{{ end }}
+              value: "http://docker-model-runner/engines/v1/"
+            - name: {{ if $value.model_var }}{{ $value.model_var }}{{ else }}{{ $key | uppercase }}_MODEL{{ end }}
+              value: "{{ or (index $.models $key).model $key }}"{{ end }}
 {{ end }}
 
 {{ if or $service.user $service.group_add $service.sysctls $service.read_only $service.privileged $service.cap_add $service.cap_drop }}

--- a/templates/overlays/desktop/deployment.tmpl
+++ b/templates/overlays/desktop/deployment.tmpl
@@ -1,0 +1,23 @@
+{{ $project := .name }}
+{{ range $name, $service := .services }}
+{{ if $service.models }}
+---
+#! {{ $name }}-deployment.yaml
+# Generated code, do not edit
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name | safe }}
+  namespace: {{ $project | safe }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: {{ if $service.container_name }}{{ $service.container_name | safe }}{{ else }}{{ $name | safe }}{{ end }}
+          env:
+{{ range $key, $value := $service.models }}
+            - name: {{ if $value.endpoint_var }}{{ $value.endpoint_var }}{{ else }}{{ $key | uppercase }}_URL{{ end }}
+              value: "http://host.docker.internal:12434/engines/v1/"
+{{ end }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
Detect when `models` have been defined in Compose configuration:
* add the env variables to the service containers
* create a new `model-runner` overlay to deploy Model Runner in pod directly inside the Kubernetes cluster
* Use local instance of Docker Model Runner when using the `desktop` overlays to benefit from the host GPU acceleration
* add support also for Helm charts