### PR TITLE
add containerized Docker Model Runner support

### DIFF
--- a/helm-templates/templates/deployment.tmpl
+++ b/helm-templates/templates/deployment.tmpl
@@ -40,8 +40,16 @@ spec:
         - name: {{ if $service.container_name }}{{ $service.container_name | safe}}{{ else }}{{ $name | safe}}{{ end }}
           image: {{ helmValue ".Values.%s.image" $name }}
           imagePullPolicy: {{ helmValue ".Values.%s.imagePullPolicy" $name }}
+{{ if $service.entrypoint }}
+          command:
+{{ range $service.entrypoint }}
+            - {{ . }}
+{{ end }}{{ end }}
 {{ if $service.command }}
-          command: {{ $service.command }}{{ end }}
+          args:
+{{ range $service.command }}
+            - {{ . }}
+{{ end }}{{ end }}
 {{ if $service.working_dir }}
           workingDir: {{ $service.working_dir }}{{ end }}
 {{ if or $service.environment $service.models }}
@@ -51,7 +59,7 @@ spec:
               value: {{ printf "%q" $value }}{{ end }}
 {{ range $key, $value := $service.models }}
             - name: {{ if $value.endpoint_var }}{{ $value.endpoint_var }}{{ else }}{{ $key | uppercase }}_URL{{ end }}
-              value: {{ helmValue ".Values.modelRunner.endpoint" }}
+              value: {{ helmValue "if .Values.modelRunner.enabled" }}"http://docker-model-runner/engines/v1/"{{ helmValue "else" }}{{ helmValue ".Values.modelRunner.hostEndpoint" }}{{ helmValue "end" }}
             - name: {{ if $value.model_var }}{{ $value.model_var }}{{ else }}{{ $key | uppercase }}_MODEL{{ end }}
               value: "{{ or (index $.models $key).model $key }}"{{ end }}
 {{ end }}

--- a/helm-templates/templates/model-runner-deployment.tmpl
+++ b/helm-templates/templates/model-runner-deployment.tmpl
@@ -1,0 +1,86 @@
+{{ $project := .name }}
+{{ if .models }}
+---
+#! model-runner-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-model-runner
+  namespace: {{ helmValue ".Values.namespace" }}
+  labels:
+    app: docker-model-runner
+    com.docker.compose.project: {{ $project }}
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: {{ helmValue "if .Values.modelRunner.enabled" }}1{{ helmValue "else" }}0{{ helmValue "end" }}
+  selector:
+    matchLabels:
+      app: docker-model-runner
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: docker-model-runner
+        com.docker.compose.project: {{ $project }}
+    spec:
+      initContainers:
+        - name: fix-permissions
+          image: busybox:1.35
+          command: ["sh", "-c", "chmod a+rwx /models"]
+          volumeMounts:
+            - name: model-storage
+              mountPath: /models
+      containers:
+        - name: model-runner
+          image: {{ helmValue ".Values.modelRunner.image" }}
+          imagePullPolicy: {{ helmValue ".Values.modelRunner.imagePullPolicy" }}
+          ports:
+            - name: http
+              containerPort: 12434
+          volumeMounts:
+            - name: model-storage
+              mountPath: /models
+          resources:
+            limits:
+              cpu: {{ helmValue ".Values.modelRunner.resources.limits.cpu" }}
+              memory: {{ helmValue ".Values.modelRunner.resources.limits.memory" }}
+            requests:
+              cpu: {{ helmValue ".Values.modelRunner.resources.requests.cpu" }}
+              memory: {{ helmValue ".Values.modelRunner.resources.requests.memory" }}
+          readinessProbe:
+            httpGet:
+              path: /engines/status
+              port: 12434
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /engines/status
+              port: 12434
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+        - name: model-init
+          image: curlimages/curl:8.14.1
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            set -ex
+            MODEL_RUNNER=http://localhost:12434
+            echo "Pre-pulling models..."
+            {{ helmValue "range .Values.modelRunner.models" }}
+            echo "Pulling model: {{ helmValue "." }}"
+            curl -d "{\"from\": \"{{ helmValue "." }}\"}" "$MODEL_RUNNER"/models/create
+            {{ helmValue "end" }}
+            echo "Model pre-pull complete"
+            tail -f /dev/null
+          volumeMounts:
+          - name: model-storage
+            mountPath: /models
+      volumes:
+      - name: model-storage
+        persistentVolumeClaim:
+          claimName: model-storage
+{{ end }}

--- a/helm-templates/templates/model-runner-pvc.tmpl
+++ b/helm-templates/templates/model-runner-pvc.tmpl
@@ -1,0 +1,22 @@
+{{ $project := .name }}
+{{ if .models }}
+---
+#! model-runner-pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-storage
+  namespace: {{ helmValue ".Values.namespace" }}
+  labels:
+    app: docker-model-runner
+    com.docker.compose.project: {{ $project }}
+    app.kubernetes.io/managed-by: Helm
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  storageClassName: {{ helmValue ".Values.modelRunner.storage.storageClass" }}
+  resources:
+    requests:
+      storage: {{ helmValue ".Values.modelRunner.storage.size" }}
+{{ end }}

--- a/helm-templates/templates/model-runner-service.tmpl
+++ b/helm-templates/templates/model-runner-service.tmpl
@@ -1,0 +1,23 @@
+{{ $project := .name }}
+{{ if .models }}
+---
+#! model-runner-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker-model-runner
+  namespace: {{ helmValue ".Values.namespace" }}
+  labels:
+    app: docker-model-runner
+    com.docker.compose.project: {{ $project }}
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 12434
+    protocol: TCP
+    name: http
+  selector:
+    app: docker-model-runner
+{{ end }}

--- a/helm-templates/values.tmpl
+++ b/helm-templates/values.tmpl
@@ -29,8 +29,33 @@ storage:
 {{ if .models }}
 # Model Runner settings
 modelRunner:
-  # Endpoint for Docker Model Runner (Docker Desktop host instance)
-  endpoint: "http://host.docker.internal:12434/engines/v1/"
+  # Set to false for Docker Desktop (uses host instance)
+  # Set to true for standalone Kubernetes clusters
+  enabled: true
+
+  # Endpoint used when enabled=false (Docker Desktop)
+  hostEndpoint: "http://host.docker.internal:12434/engines/v1/"
+
+  # Deployment settings when enabled=true
+  image: "docker/model-runner:latest"
+  imagePullPolicy: "IfNotPresent"
+
+  resources:
+    limits:
+      cpu: "1000m"
+      memory: "2Gi"
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+
+  # Storage for models
+  storage:
+    size: "100Gi"
+    storageClass: ""  # Empty uses default storage class
+
+  # Models to pre-pull
+  models:{{ range $name, $model := .models }}
+    - {{ $model.model }}{{ end }}
 {{ end }}
 
 # Services variables

--- a/templates/base/deployment.tmpl
+++ b/templates/base/deployment.tmpl
@@ -39,8 +39,16 @@ spec:
         - name: {{ if $service.container_name }}{{ $service.container_name | safe }}{{ else }}{{ $name | safe }}{{ end }}
           image: {{ if $service.image }}{{ $service.image }}{{ else }}{{ $project }}-{{ $name }}{{ end }}
           imagePullPolicy: {{ if $service.pull_policy }}{{ $service.pull_policy | title }}{{ else }}IfNotPresent{{ end }}
+{{ if $service.entrypoint }}
+          command:
+{{ range $service.entrypoint }}
+            - {{ . }}
+{{ end }}{{ end }}
 {{ if $service.command }}
-          command: {{ $service.command }}{{ end }}
+          args:
+{{ range $service.command }}
+            - {{ . }}
+{{ end }}{{ end }}
 {{ if $service.working_dir }}
           workingDir: {{ $service.working_dir }}{{ end }}
 {{ if or $service.environment $service.models }}

--- a/templates/overlays/model-runner/_index.tmpl
+++ b/templates/overlays/model-runner/_index.tmpl
@@ -1,0 +1,12 @@
+#! kustomization.yaml
+# Generated code, do not edit
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+{{ range . }}
+  {{ if ne .Name "kustomization.yaml" }}
+- {{ .Name }}
+  {{ end }}
+{{ end }}

--- a/templates/overlays/model-runner/model-runner-configmap.tmpl
+++ b/templates/overlays/model-runner/model-runner-configmap.tmpl
@@ -1,0 +1,18 @@
+{{ $project := .name }}
+{{ if .models }}
+---
+#! model-runner-configmap.yaml
+# Generated code, do not edit
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docker-model-runner-init
+  namespace: {{ $project | safe }}
+  labels:
+    com.docker.compose.project: {{ $project }}
+    com.docker.model.runner: "true"
+data:
+  models: |{{ range $name, $model := .models }}
+{{ indent $model.model 4 }}
+{{ end }}
+{{ end }}

--- a/templates/overlays/model-runner/model-runner-deployment.tmpl
+++ b/templates/overlays/model-runner/model-runner-deployment.tmpl
@@ -1,0 +1,94 @@
+{{ $project := .name }}
+{{ if .models }}
+---
+#! model-runner-deployment.yaml
+# Generated code, do not edit
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-model-runner
+  namespace: {{ $project | safe }}
+  labels:
+    com.docker.compose.project: {{ $project }}
+    com.docker.model.runner: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      com.docker.compose.project: {{ $project }}
+      com.docker.model.runner: "true"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        com.docker.compose.project: {{ $project }}
+        com.docker.model.runner: "true"
+    spec:
+      restartPolicy: Always
+      initContainers:
+        - name: fix-permissions
+          image: busybox:1.35
+          command: ["sh", "-c", "chmod a+rwx /models"]
+          volumeMounts:
+            - name: model-storage
+              mountPath: /models
+      containers:
+        - name: model-runner
+          image: docker/model-runner:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 12434
+          volumeMounts:
+            - name: model-storage
+              mountPath: /models
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /engines/status
+              port: 12434
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /engines/status
+              port: 12434
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+        - name: model-init
+          image: curlimages/curl:8.14.1
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            set -ex
+            MODEL_RUNNER=http://localhost:12434
+            echo "Pre-pulling models..."
+            while IFS= read -r model; do
+              if [ -n "$model" ]; then
+                echo "Pulling model: $model"
+                curl -d "{\"from\": \"$model\"}" "$MODEL_RUNNER"/models/create
+              fi
+            done < /config/models
+            echo "Model pre-pull complete"
+            tail -f /dev/null
+          volumeMounts:
+          - name: model-storage
+            mountPath: /models
+          - name: init-config
+            mountPath: /config
+      volumes:
+      - name: model-storage
+        persistentVolumeClaim:
+          claimName: model-storage
+      - name: init-config
+        configMap:
+          name: docker-model-runner-init
+{{ end }}

--- a/templates/overlays/model-runner/model-runner-service.tmpl
+++ b/templates/overlays/model-runner/model-runner-service.tmpl
@@ -1,0 +1,24 @@
+{{ $project := .name }}
+{{ if .models }}
+---
+#! model-runner-service.yaml
+# Generated code, do not edit
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker-model-runner
+  namespace: {{ $project | safe }}
+  labels:
+    com.docker.compose.project: {{ $project }}
+    com.docker.model.runner: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 12434
+    protocol: TCP
+    name: http
+  selector:
+    com.docker.compose.project: {{ $project }}
+    com.docker.model.runner: "true"
+{{ end }}

--- a/templates/overlays/model-runner/model-runner-volume-claim.tmpl
+++ b/templates/overlays/model-runner/model-runner-volume-claim.tmpl
@@ -1,0 +1,21 @@
+{{ $project := .name }}
+{{ if .models }}
+---
+#! model-runner-volume-claim.yaml
+# Generated code, do not edit
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-storage
+  namespace: {{ $project | safe }}
+  labels:
+    com.docker.compose.project: {{ $project }}
+    com.docker.model.runner: "true"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 100Gi
+{{ end }}


### PR DESCRIPTION
Support for deploying Docker Model Runner as pods in Kubernetes clusters:

Kubernetes templates:
- Added model environment variables injection to base deployment template
- Created model-runner overlay with full Model Runner deployment (init containers, main container, model-init sidecar)
- Includes ConfigMap for model list, Service (ClusterIP), and PersistentVolumeClaim for model storage

Helm templates:
- Added modelRunner configuration section in values.yaml with enabled flag
- Created conditional model-runner-deployment.tmpl (replicas controlled by modelRunner.enabled)
- Created model-runner-service.tmpl and model-runner-pvc.tmpl
- Updated deployment template to inject model env vars with conditional endpoint based on modelRunner.enabled
- When enabled=true: uses in-cluster Model Runner at http://docker-model-runner/engines/v1/
- When enabled=false: uses Docker Desktop host at http://host.docker.internal:12434/engines/v1/

This allows users to choose between:
1. Docker Desktop: Set modelRunner.enabled=false (uses host Model Runner, no pods deployed)
2. Standalone Kubernetes: Set modelRunner.enabled=true (deploys Model Runner in cluster)