### PR TITLE
Remove egress restriction from generated NetworkPolicy

### DIFF
--- a/helm-templates/templates/networkpolicy.tmpl
+++ b/helm-templates/templates/networkpolicy.tmpl
@@ -13,14 +13,8 @@ spec:
       com.docker.compose.network.{{ $name }}: "true"
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
-      - podSelector:
-          matchLabels:
-            com.docker.compose.network.{{ $name }}: "true"
-  egress:
-    - to:
       - podSelector:
           matchLabels:
             com.docker.compose.network.{{ $name }}: "true"

--- a/templates/base/networkpolicy.tmpl
+++ b/templates/base/networkpolicy.tmpl
@@ -14,14 +14,8 @@ spec:
       com.docker.compose.network.{{ $name }}: "true"
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
-      - podSelector:
-          matchLabels:
-            com.docker.compose.network.{{ $name }}: "true"
-  egress:
-    - to:
       - podSelector:
           matchLabels:
             com.docker.compose.network.{{ $name }}: "true"


### PR DESCRIPTION
The NetworkPolicy template was restricting both ingress and egress to pods within the same Compose network. This incorrectly blocks DNS resolution (CoreDNS) and any outbound traffic to external services, the host, or non-Compose pods (e.g. telepresence traffic-manager).

Docker Compose's network model only restricts which services can reach each other (ingress), not where they can send traffic. Pods on a Compose network can freely reach DNS, the internet, and the host.

This was previously invisible because common CNIs (Docker Desktop's vpnkit, older kindnet) did not enforce NetworkPolicies. kind v1.34.3+ now ships kindnet with kube-network-policies enabled, making the overly restrictive policy actively break DNS and inter-service communication.