### PR TITLE
fix: cross-compile binaries for the requested target platform

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.github
+.idea
+.claude
+CLAUDE.md
+README.md
+LICENSE
+Dockerfile
+docker-bake.hcl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
+FROM --platform=${BUILDPLATFORM} tonistiigi/xx:1.9.0 AS xx
+
 FROM --platform=${BUILDPLATFORM} golang:1.24.5 AS builder
+COPY --from=xx / /
+RUN xx-verify --setup
 WORKDIR $GOPATH/src/github.com/docker/compose-bridge-transformer
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-RUN go build -o /go/bin/transform
+ARG TARGETOS TARGETARCH TARGETVARIANT
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} \
+    go build -o /go/bin/transform && \
+    xx-verify --static /go/bin/transform
 
 FROM scratch AS transformer
 LABEL com.docker.compose.bridge=transformation


### PR DESCRIPTION
All published platform variants (386, arm/v6, arm/v7, arm64, ppc64le) contained the same amd64 binary: the builder stage runs on BUILDPLATFORM but go build never set GOOS/GOARCH, so images only worked where emulation (e.g. Rosetta) was available.

Build with explicit GOOS/GOARCH/GOARM from BuildKit platform args and add an xx-verify --static guard so any future cross-compile regression fails the build instead of publishing wrong-arch images. Also split go.mod/go.sum into their own layer for module cache reuse and add a .dockerignore to keep the build context minimal.