### PR TITLE
ci: publish images to Docker Hub using OIDC

### DIFF
--- a/.github/workflows/transformer-images.yaml
+++ b/.github/workflows/transformer-images.yaml
@@ -15,15 +15,19 @@ on:
 jobs:
   transformer-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      id-token: write # for OIDC token exchange with Docker Hub
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: 472b49bc-6912-46f1-a731-e7e804b6a0c8
         with:
-          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
-          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+          username: docker
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
@@ -58,6 +62,9 @@ jobs:
             *.cache-to=type=gha,scope=transformer-images,mode=max
   kubernetes-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      id-token: write # for OIDC token exchange with Docker Hub
     needs:
       - transformer-image
     steps:
@@ -65,10 +72,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: 472b49bc-6912-46f1-a731-e7e804b6a0c8
         with:
-          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
-          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+          username: docker
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
@@ -103,6 +111,9 @@ jobs:
             *.cache-to=type=gha,scope=transformer-images,mode=max
   helm-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      id-token: write # for OIDC token exchange with Docker Hub
     needs:
       - transformer-image
     steps:
@@ -110,10 +121,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: 472b49bc-6912-46f1-a731-e7e804b6a0c8
         with:
-          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
-          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+          username: docker
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx


### PR DESCRIPTION
Replace the long-lived DOCKERPUBLICBOT PAT with short-lived tokens minted through the Docker Hub OIDC connection, natively supported by docker/login-action since v4.5.1.

The connection rulesets cover both pushing triggers of this workflow (refs/heads/main and refs/tags/v*) for the transformer, kubernetes and helm images. Pull requests keep skipping the registry login, and each image job now declares the least privileges it needs (contents: read, id-token: write).